### PR TITLE
Fix unknown host key error for new devices

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,8 +22,8 @@ copyright = '2021, Nokia'
 author = 'Nokia'
 
 # The full version, including alpha/beta/rc tags
-version = '21.10.2'
-release = '21.10.2'
+version = '21.10.3'
+release = '21.10.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,8 +22,8 @@ copyright = '2021, Nokia'
 author = 'Nokia'
 
 # The full version, including alpha/beta/rc tags
-version = '21.10.1'
-release = '21.10.1'
+version = '21.10.2'
+release = '21.10.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/ehs.rst
+++ b/docs/source/ehs.rst
@@ -1,93 +1,131 @@
-:mod:`ehs` -- Functions specific to the event handling system (EHS)
-===================================================================
 
-.. module:: ehs
-   :synopsis: Functions specific for the SR OS event handling system (EHS)
-
-This module is used when executing on SR OS only.  On a remote machine, the
-event handling system (EHS) and its functionality are not supported.
-
-The :mod:`ehs` module provides functions for obtaining the data from the
+The :mod:`pysros.ehs` module provides functionality to obtain data from the
 specific event that triggered the execution of a Python application from
 the event handling system (EHS).
 
-.. Reviewed by PLM 20211201
-.. Reviewed by TechComms 20211202
+.. Reviewed by PLM 20220118
+.. Reviewed by TechComms 20220120
 
-Classes
--------
+.. note:: This module is available when executing on SR OS only. On a remote
+          machine, the event handling system (EHS) and its functionality
+          are not supported.
 
-.. class:: get_event
+.. Reviewed by PLM 20220117
+.. Reviewed by TechComms 20220124
+
+.. py:function:: get_event
 
    The EHS event that triggered the execution of the Python application.
 
-      .. function:: appid
+   :return: The Event object or None.
+   :rtype: :py:class:`pysros.ehs.Event` or ``None``
 
-         The name of the application that generated the event.
+   .. Reviewed by PLM 20220118
+   .. Reviewed by TechComms 20220124
 
-         :return: Application name.
-         :rtype: str
+.. class:: Event
 
-         .. Reviewed by PLM 20211201
-         .. Reviewed by TechComms 20211202
+   The EHS event Class for the event that triggered the execution of the
+   Python application.
 
-      .. function:: eventid
+   .. py:attribute:: appid
 
-         The event ID number of the application.
+      The name of the application that generated the event.
 
-         :return: Event ID.
-         :rtype: int
+      :type: str
 
-         .. Reviewed by PLM 20211201
-         .. Reviewed by TechComms 20211202
+      .. Reviewed by PLM 20220118
+      .. Reviewed by TechComms 20220124
 
-      .. function:: severity
+   .. py:attribute:: eventid
 
-         The severity level of the event.
+      The event ID number of the application.
 
-         :return: Severity of the event.
-         :rtype: str
+      :type: int
 
-         .. Reviewed by PLM 20211201
-         .. Reviewed by TechComms 20211202
+      .. Reviewed by PLM 20220118
+      .. Reviewed by TechComms 20220124
 
-      .. function:: subject
+   .. py:attribute:: severity
 
-         The subject or affected object of the event.
+      The severity level of the event.
 
-         :return: Subject or affected object.
-         :rtype: str
+      :type: str
 
-         .. Reviewed by PLM 20211201
-         .. Reviewed by TechComms 20211202
+      .. Reviewed by PLM 20220118
+      .. Reviewed by TechComms 20220124
 
-      .. function:: gentime
+   .. py:attribute:: subject
 
-         The formatted time the event was generated in UTC.
+      The subject or affected object of the event.
 
-         :return: The timestamp in ISO 8601 format that the event was generated.
-         :rtype: str
+      :type: str
 
-         .. Reviewed by PLM 20211201
-         .. Reviewed by TechComms 21211202
+      .. Reviewed by PLM 20220118
+      .. Reviewed by TechComms 20220124
 
-      .. function:: timestamp
+   .. py:attribute:: gentime
 
-         The formatted time the event was generated.
+      The formatted time, in ISO 8601 format, that the event was generated.
 
-         :return: The timestamp in seconds.
-         :rtype: float
+      :type: str
 
-         .. Reviewed by PLM 20211201
-         .. Reviewed by TechComms 21211202
+     .. Reviewed by PLM 20220118
+     .. Reviewed by TechComms 20220124
 
-      .. function:: eventparameters
+   .. py:attribute:: timestamp
 
-         The additional parameters specific to the event that caused the
-         Python application to execute.
+      The timestamp, in seconds, that the event was generated.
 
-         :return: Additional attributes of the specific event.
-         :rtype: dict
+      :type: float
 
-         .. Reviewed by PLM 20211201
-         .. Reviewed by TechComms 21211202
+      .. Reviewed by PLM 20220118
+      .. Reviewed by TechComms 20220124
+
+   .. function:: eventparameters
+
+      The additional parameters specific to the event that caused the
+      Python application to execute.
+
+      :type: :py:class:`pysros.ehs.EventParams`
+
+      .. Reviewed by PLM 20220118
+      .. Reviewed by TechComms 20220124
+
+   .. py:method:: format_msg
+
+      Return a string representation of the SR OS formatted log message.
+
+      :return: SR OS formatted log message.
+      :rtype: str
+
+      .. Reviewed by PLM 20220118
+      .. Reviewed by TechComms 20220124
+
+.. class:: EventParams
+
+   The additional parameters of the specific :py:class:`pysros.ehs.Event`.
+   This class is *read-only*.  Specific additional parameters may be
+   accessed using standard Python subscript syntax.
+
+   .. Reviewed by PLM 20220118
+   .. Reviewed by TechComms 20220124
+
+   .. py:method:: keys
+
+      Obtain the additional parameters names.
+
+      :return: Additional parameters names for the Event.
+      :rtype: tuple(str)
+
+      .. Reviewed by PLM 20220118
+      .. Reviewed by TechComms 20220124
+
+      .. describe:: params[key]
+
+      Return the value of the parameter *key*. If the parameter does not exist,
+      a :exc:`KeyError` is raised.
+
+      .. Reviewed by PLM 20220118
+      .. Reviewed by TechComms 20220124
+

--- a/docs/source/ehs.rst
+++ b/docs/source/ehs.rst
@@ -1,0 +1,93 @@
+:mod:`ehs` -- Functions specific to the event handling system (EHS)
+===================================================================
+
+.. module:: ehs
+   :synopsis: Functions specific for the SR OS event handling system (EHS)
+
+This module is used when executing on SR OS only.  On a remote machine, the
+event handling system (EHS) and its functionality are not supported.
+
+The :mod:`ehs` module provides functions for obtaining the data from the
+specific event that triggered the execution of a Python application from
+the event handling system (EHS).
+
+.. Reviewed by PLM 20211201
+.. Reviewed by TechComms 20211202
+
+Classes
+-------
+
+.. class:: get_event
+
+   The EHS event that triggered the execution of the Python application.
+
+      .. function:: appid
+
+         The name of the application that generated the event.
+
+         :return: Application name.
+         :rtype: str
+
+         .. Reviewed by PLM 20211201
+         .. Reviewed by TechComms 20211202
+
+      .. function:: eventid
+
+         The event ID number of the application.
+
+         :return: Event ID.
+         :rtype: int
+
+         .. Reviewed by PLM 20211201
+         .. Reviewed by TechComms 20211202
+
+      .. function:: severity
+
+         The severity level of the event.
+
+         :return: Severity of the event.
+         :rtype: str
+
+         .. Reviewed by PLM 20211201
+         .. Reviewed by TechComms 20211202
+
+      .. function:: subject
+
+         The subject or affected object of the event.
+
+         :return: Subject or affected object.
+         :rtype: str
+
+         .. Reviewed by PLM 20211201
+         .. Reviewed by TechComms 20211202
+
+      .. function:: gentime
+
+         The formatted time the event was generated in UTC.
+
+         :return: The timestamp in ISO 8601 format that the event was generated.
+         :rtype: str
+
+         .. Reviewed by PLM 20211201
+         .. Reviewed by TechComms 21211202
+
+      .. function:: timestamp
+
+         The formatted time the event was generated.
+
+         :return: The timestamp in seconds.
+         :rtype: float
+
+         .. Reviewed by PLM 20211201
+         .. Reviewed by TechComms 21211202
+
+      .. function:: eventparameters
+
+         The additional parameters specific to the event that caused the
+         Python application to execute.
+
+         :return: Additional attributes of the specific event.
+         :rtype: dict
+
+         .. Reviewed by PLM 20211201
+         .. Reviewed by TechComms 21211202

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,11 +16,11 @@ documentation will be updated accordingly.
 .. list-table::
    :header-rows: 0
 
-   * - pySROS release: 21.10.2
-   * - Document Number: 3HE 17936 AAAD TQZZA
+   * - pySROS release: 21.10.3
+   * - Document Number: 3HE 17936 AAAE TQZZA
 
-.. Reviewed by PLM 20211201
-.. Reviewed by TechComms 20211202
+.. Reviewed by PLM 20220113
+.. Reviewed by TechComms 20220114
 
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,11 +16,11 @@ documentation will be updated accordingly.
 .. list-table::
    :header-rows: 0
 
-   * - pySROS release: 21.10.1
-   * - Document Number: 3HE 17936 AAAC TQZZA
+   * - pySROS release: 21.10.2
+   * - Document Number: 3HE 17936 AAAD TQZZA
 
-.. Reviewed by PLM 20210902
-.. Reviewed by TechComms 20210902
+.. Reviewed by PLM 20211201
+.. Reviewed by TechComms 20211202
 
 
 .. toctree::

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -6,7 +6,7 @@ pySROS modules
 
    pysros
 
-Libraries adapted for SR OS
+Libraries specific to SR OS
 ===========================
 
 The adapted versions of the modules documented here, are provided when
@@ -14,8 +14,9 @@ executing on SR OS only.  When executing on a remote device, the native
 Python versions of the library are used.
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 6
 
    utime
+   ehs
 
 

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -6,6 +6,7 @@ pySROS modules
 
    pysros
 
+
 Libraries specific to SR OS
 ===========================
 
@@ -17,6 +18,6 @@ Python versions of the library are used.
    :maxdepth: 6
 
    utime
-   ehs
+
 
 

--- a/docs/source/pysros.rst
+++ b/docs/source/pysros.rst
@@ -44,6 +44,21 @@
    :undoc-members:
    :show-inheritance:
 
+:mod:`pysros.ehs` - Functions for the event handling system (EHS)
+-------------------------------------------------------------------------
+
+.. module:: pysros.ehs
+   :synopsis: Functions for the SR OS event handling system (EHS)
+
+.. include:: ehs.rst
+
+
+
+
+
+
+
+
 
 
 

--- a/examples/show_router_bgp_asn.py
+++ b/examples/show_router_bgp_asn.py
@@ -124,7 +124,7 @@ def show_router_bgp_asn_output(connection_object, asn):
             '/nokia-conf:configure/router[router-name="Base"]/bgp/neighbor'
         )
     except LookupError as lookup_error:
-        print("Failed to get BGP neighbor configuration.  Are any neigbors configured?")
+        print("Failed to get BGP neighbor configuration.  Are any neighbors configured?")
         print("Error:", lookup_error, end="")
         print(".")
         sys.exit(102)

--- a/pysros/errors.py
+++ b/pysros/errors.py
@@ -3,6 +3,11 @@
 from .exceptions import *
 from .exceptions import make_exception
 
+__doc__ = """This module contains error definitions for pySROS.
+
+.. reviewed by PLM 20211201
+.. reviewed by TechComms 20211202
+"""
 
 pysros_err_arg_must_be_string = (TypeError, """Argument "module" must be a string""")
 pysros_err_attr_cannot_be_deleted = (AttributeError, "'{obj}' object attribute '{attribute}' cannot be deleted")

--- a/pysros/exceptions.py
+++ b/pysros/exceptions.py
@@ -2,6 +2,13 @@
 
 __all__ = ("SrosMgmtError", "InvalidPathError", "ModelProcessingError", "InternalError", "SrosConfigConflictError", "ActionTerminatedIncompleteError", )
 
+__doc__ = """This module contains exceptions for error handling within pySROS.
+
+.. reviewed by PLM 20211201
+.. reviewed by TechComms 20211202
+"""
+
+
 class SrosMgmtError(Exception):
     """Exception raised by the :mod:`pysros.management` objects when:
 
@@ -50,19 +57,31 @@ class InternalError(Exception):
     pass
 
 class SrosConfigConflictError(Exception):
-    """Exception raised when a configuration commit failed due to conflicts between the ``candidate``
-    datastore and the ``baseline`` datastore.  Retrying the configuration operation usually resolves the
-    situation.  If retrying does not resolve the issue, the connection should be closed using
-    :py:meth:`pysros.management.Connection.disconnect` and the operation restarted to make a new connection.
+    """Exception raised when a configuration commit failed due to conflicts
+    between the ``candidate`` datastore and the ``baseline`` datastore.
+    Retrying the configuration operation usually resolves the situation.
+    If retrying does not resolve the issue, the connection should be closed using
+    :py:meth:`pysros.management.Connection.disconnect` and the operation
+    restarted to make a new connection.
 
-    .. Reviewed by PLM 20210625
-    .. Reviewed by TechComms 20210630
+    .. Reviewed by PLM 20211201
+    .. Reviewed by TechComms 20211202
     """
     pass
 
 class ActionTerminatedIncompleteError(Exception):
-    """Exception raised when an action completes with a ``terminated-incomplete`` status"""
+    """Exception raised when an operation (also known as an action)
+    completes with a ``terminated-incomplete`` status.
+
+    .. Reviewed by PLM 20211201
+    .. Reviewed by TechComms 20211202
+    """
     pass
 
 def make_exception(arg, **kwarg):
+    """Create an exception.
+
+    .. Reviewed by PLM 20211201
+    .. Reviewed by TechComms 20211202
+    """
     return arg[0](arg[1].format(**kwarg))

--- a/pysros/management.py
+++ b/pysros/management.py
@@ -135,7 +135,7 @@ def connect(*, host, port=830, username, password=None, yang_directory=None,
     return Connection(host=host, port=port, username=username, password=password,
                       device_params={'name': 'sros'}, manager_params={'timeout': timeout},
                       nc_params={'capabilities':['urn:nokia.com:nc:pysros:pc']},
-                      yang_directory=yang_directory, rebuild=rebuild)
+                      yang_directory=yang_directory, rebuild=rebuild, hostkey_verify=False)
 
 def sros():
     """Determine whether the execution environment is an SR OS node

--- a/pysros/pprint.py
+++ b/pysros/pprint.py
@@ -5,6 +5,13 @@ from .errors import *
 
 __all__ = ("TreePrinter", "printTree", "Column", "Padding", "Table", "KeyValueTable", )
 
+__doc__ = """This module contains functions to assist with stylized
+formatting of data.
+
+.. reviewed by PLM 20211201
+.. reviewed by TechComms 20211202
+"""
+
 def _signalLast(iterable):
     iterable = iter(iterable)
     try:
@@ -24,7 +31,8 @@ def _groupByTwo(it):
             break
 
 class TreePrinter:
-    """Object used to print the result of a call to :py:meth:`pysros.management.Datastore.get` as an ASCII tree.
+    """Object used to print the result of a call
+    to :py:meth:`pysros.management.Datastore.get` as an ASCII tree.
 
     :param align: Whether to align values of a container in the same column.
     :type align: bool
@@ -34,10 +42,11 @@ class TreePrinter:
 
 
     .. note::
-       The :py:meth:`pysros.pprint.printTree` function provides a simple way to use this object.
+       The :py:meth:`pysros.pprint.printTree` function provides a
+       simple way to use this object.
 
-    .. Reviewed by PLM 20210625
-    .. Reviewed by TechComms 20210713
+    .. Reviewed by PLM 20211201
+    .. Reviewed by TechComms 20211202
     """
     def __init__(self, *, align=False, depth=None):
         self.align = bool(align)
@@ -96,7 +105,8 @@ class TreePrinter:
         branches.pop()
 
 def printTree(obj, **kwargs):
-    """Print the result of a call to :py:meth:`pysros.management.Datastore.get` as an ASCII tree.
+    """Print the result of a call to :py:meth:`pysros.management.Datastore.get`
+    as an ASCII tree.
 
     See arguments of :class:`.TreePrinter`
 
@@ -117,27 +127,30 @@ def printTree(obj, **kwargs):
        if __name__ == "__main__":
            main()
 
-    .. Reviewed by PLM 20210628
-    .. Reviewed by TechComms 20210705
+    .. Reviewed by PLM 20211201
+    .. Reviewed by TechComms 20211202
     """
     TreePrinter(**kwargs).print(obj)
 
 class Column:
-    """Column descriptor to be used in :class:`pysros.pprint.Table` and :class:`pysros.pprint.KeyValueTable`.
+    """Column descriptor to be used in :class:`pysros.pprint.Table`
+    and :class:`pysros.pprint.KeyValueTable`.
 
     :param width: Width of the column (number of characters).
     :type width: int
-    :param name: Name of the column. This may be None when column headers are not to be printed. Default None.
+    :param name: Name of the column. This may be None when column
+                 headers are not to be printed. Default None.
     :type name: None, str
-    :param align: Alignment of the column: '<' for left, '>' for right and '^' for centered.  Defaults to '<'.
+    :param align: Alignment of the column: '<' for left, '>' for right
+                  and '^' for centered.  Defaults to '<'.
     :type align: str
-    :param padding: Number of padding characters, already accounted for in width.  Default 0.
+    :param padding: Number of padding characters, already accounted
+                    for in width.  Default 0.
     :type padding: int
     :raises ValueError: Error if align is not valid.
 
-    .. Reviewed by PLM 20210628
-    .. Reviewed by TechComms 20210712
-
+    .. Reviewed by PLM 20211201
+    .. Reviewed by TechComms 20211202
     """
     def __init__(self, width, name=None, align='<', padding=0):
         if align != '<' and align != '>' and align != '^':
@@ -262,13 +275,15 @@ class Table(ATable):
 
     :param title: Title of the table.
     :type title: str
-    :param columns: List of column descriptions. Elements of the list can be a :py:class:`pysros.pprint.Column` or
-                    a tuple with parameters to be passed to :py:meth:`pysros.pprint.Column.create`.
+    :param columns: List of column descriptions. Elements of the list can
+                    be a :py:class:`pysros.pprint.Column` or a tuple with
+                    parameters to be passed to :py:meth:`pysros.pprint.Column.create`.
     :param width: Width of the table in characters.
     :type width: int
     :param showCount: Indicate if a count of rows should be shown in the footer.
                       In case no count is required, pass in None.
-                      In case a count is required, pass in the name of the object represented in a row.
+                      In case a count is required, pass in the name of the object
+                      represented in a row.
     :param summary: Optional block of text to be displayed in the footer.
     :type summary: str
 
@@ -287,15 +302,15 @@ class Table(ATable):
            rows = [["row0col0", "row0col1"], ["row1col0", "row1col1"]]
            cols = [(30, "Column0"), (30, "Column1")]
            width = sum([col[0] for col in cols])
-           table = Table("This is my tables title", columns=cols, showCount="CounterName", summary=summary, width=width)
+           table = Table("This is my tables title", columns=cols,
+                         showCount="CounterName", summary=summary, width=width)
            return table, rows
 
        if __name__ == "__main__":
            table, rows = simple_table_builder_example()
 
-    .. Reviewed by PLM 20210628
-    .. Reviewed by TechComms 20210712
-
+    .. Reviewed by PLM 20211201
+    .. Reviewed by TechComms 20211202
     """
     def __init__(self, title, columns, width=79, showCount=None, summary=None):
         super().__init__(title, width=width)

--- a/pysros/request_data.py
+++ b/pysros/request_data.py
@@ -541,7 +541,7 @@ class _ListSetter(_ASetter):
         keys = {}
         for e in value:
             if _get_tag(e) in self._walker.get_local_key_names():
-                keys[_get_tag(e)] = e.text
+                keys[_get_tag(e)] = e.text or ""
         if set(keys.keys()) != set(self._walker.get_local_key_names()):
             raise make_exception(pysros_err_schema_box_keys_mismatch, schema_keys=self._walker.get_local_key_names(), box_keys=list(keys.keys()))
         return self.entry_nocheck(keys)

--- a/pysros/wrappers.py
+++ b/pysros/wrappers.py
@@ -8,10 +8,11 @@ from .errors import *
 
 __all__ = ("Container", "Leaf", "LeafList")
 
-__doc__ = """This module contains wrappers describing the YANG structure and metadata obtained from SR OS.
+__doc__ = """This module contains wrappers describing the YANG 
+structure and metadata obtained from SR OS.
 
-.. Reviewed by PLM 20210630
-.. Reviewed by TechComms 20211013
+.. Reviewed by PLM 20211201
+.. Reviewed by TechComms 20211202
 """
 
 class Schema:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ncclient~=0.6.12
-lxml~=4.6.1
+lxml~=4.6.3

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name='pysros',
-    version='21.10.1',
+    version='21.10.2',
     packages=['pysros'],
     url='https://www.nokia.com',
     license='Copyright 2021 Nokia.  License available in the LICENSE.md file.',
@@ -27,7 +27,7 @@ setup(
     ],
     install_requires=[
         "ncclient~=0.6.12",
-        "lxml~=4.6.1",
+        "lxml~=4.6.3",
     ],
     python_requires=">=3.6",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name='pysros',
-    version='21.10.2',
+    version='21.10.3',
     packages=['pysros'],
     url='https://www.nokia.com',
     license='Copyright 2021 Nokia.  License available in the LICENSE.md file.',


### PR DESCRIPTION
```
>>> from pysros.management import connect
>>> c = connect(host='10.10.10.111', username='admin', password='admin')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/.conda/envs/py3/lib/python3.9/site-packages/pysros/management.py", line 135, in connect
    return Connection(host=host, port=port, username=username, password=password,
  File "/home/ubuntu/.conda/envs/py3/lib/python3.9/site-packages/pysros/management.py", line 197, in __init__
    raise make_exception(pysros_err_could_not_create_conn, reason=e) from None
RuntimeError: Cannot create connection - Unknown host key [da:5a:89:3c:68:98:66:1a:59:c4:b3:36:95:e9:76:37] for [10.10.10.111]
>>>

```